### PR TITLE
Add forge deploys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,24 +3,28 @@ sudo: false
 language: php
 
 php:
-  - '7.0'
-  - '7.1'
-  - 'nightly'
+- '7.0'
+- '7.1'
 
 dist: trusty
 
 os: linux
 
 before_install:
-  - alias composer="php-n -d memory_limit=-1 $(which composer)"
-  - composer self-update --stable
-  - composer install --prefer-dist --no-interaction --no-suggest
+- alias composer="php-n -d memory_limit=-1 $(which composer)"
+- composer self-update --stable
+- composer install --prefer-dist --no-interaction --no-suggest
 
 script:
-  - php artisan key:generate --env=testing
-  - php -r "file_exists('.env.testing') || copy('.env.example', '.env.testing');"
-  - php vendor/bin/codecept run --verbose --fail-fast --debug --no-interaction
+- php artisan key:generate --env=testing
+- php -r "file_exists('.env.testing') || copy('.env.example', '.env.testing');"
+- php vendor/bin/codecept run --verbose --fail-fast --debug --no-interaction
+
+after_success:
+  "[ $TRAVIS_BRANCH == \"master\" ] && curl -X POST $FORGE_DEPLOYMENT_TRIGGER_URL"
 
 notifications:
   slack:
-    secure: "gz0TCFryRQIJtHC8nx3B6AI+xtYxzTsMepJOacxzl+Q/uhWt5kquv80Geij8uUkCm4lKnMMfreg0g6f0+F2tvlz+/pR5oE462rEg9q03gVi7Eh6bICi2MKPUYWb7mvv832kZrD3od4uW+tl/N6vxmn0jNsr9MIGKvFD3aNqEvbHCHpmMvVSWnA21zkNkAxXN+ag0aos+5sNU2BaEq00dmEi2XvpaMWjvWXQOn30A1oZEcGNq+q2YtG/r1/DPLV3acxWswrnL/ZGF7YmiI31WHVPK4D0OP5oXNUgQHGhF/48nsA67NCmp7TV4aPjjMmqYSVcWq409Oic+Be1eOGPKWY4qjgE0t7JF4Nf7dRRNkLo9qeHrHe6eJsMB8rNQ8oO66ZnxQjqRlFjBAop6+Vu+zxGXvWmsHsJpI6OqHwOL1ypKaroUyFfdTxpkYoaxib4CxR2gxjBWSzCZqv1SRIsJrUI2pw9lR7YvGVCrqNmncMst8Ba3dXxYK+4PphuzklE9pmBi1BpRVNBc2g2n9aOlKkZ6cbpcVoonqXaE/v/0sJjuquFr6R8zOdKBdn7e/z0YGwmnv+0Mn6GTJYIyZhQVwLVxfuccNgb6+YO+ss+U/AGgpwJ02gslB+126AtSwOWCCAL+il5PLEtjgBpO19eEZxP6SGiws62c/R4KGK349XI="
+    secure: gz0TCFryRQIJtHC8nx3B6AI+xtYxzTsMepJOacxzl+Q/uhWt5kquv80Geij8uUkCm4lKnMMfreg0g6f0+F2tvlz+/pR5oE462rEg9q03gVi7Eh6bICi2MKPUYWb7mvv832kZrD3od4uW+tl/N6vxmn0jNsr9MIGKvFD3aNqEvbHCHpmMvVSWnA21zkNkAxXN+ag0aos+5sNU2BaEq00dmEi2XvpaMWjvWXQOn30A1oZEcGNq+q2YtG/r1/DPLV3acxWswrnL/ZGF7YmiI31WHVPK4D0OP5oXNUgQHGhF/48nsA67NCmp7TV4aPjjMmqYSVcWq409Oic+Be1eOGPKWY4qjgE0t7JF4Nf7dRRNkLo9qeHrHe6eJsMB8rNQ8oO66ZnxQjqRlFjBAop6+Vu+zxGXvWmsHsJpI6OqHwOL1ypKaroUyFfdTxpkYoaxib4CxR2gxjBWSzCZqv1SRIsJrUI2pw9lR7YvGVCrqNmncMst8Ba3dXxYK+4PphuzklE9pmBi1BpRVNBc2g2n9aOlKkZ6cbpcVoonqXaE/v/0sJjuquFr6R8zOdKBdn7e/z0YGwmnv+0Mn6GTJYIyZhQVwLVxfuccNgb6+YO+ss+U/AGgpwJ02gslB+126AtSwOWCCAL+il5PLEtjgBpO19eEZxP6SGiws62c/R4KGK349XI=
+env:
+  - secure: TFJk6mdo8Mx6scqfbUH0aC6x1J2nFi7X5g2u++R+AhRHcdqXhAijC7Lyz7XgMMHzG+mXuLeVR4VWB5F41e12g6Nwrm25nmlaeuXtqeYqzPvxE0hx6qqnub24ZIJRvOdR2GGYCrsgkVUjF28BxRiw7xkINCr3lYTvxiLkQZwN/ZjL1JF0l6tJ9hevakOZPxASx4RiTWsUoemotvDkV+Yt7oRn0pNQRGO0V7YSnIjGSaY+OzioVhKGe9Tv+EnrkGfKw1zHkjtEZfmKcZedBFgTLnhy7+OVNVIaL3MtPq9ozsyxDI8oeU5oU3TOTCwlJdbtsP6icD5bzw56ucZOnpHEnl2K8hIkN92/o6QpGjdcK2sFkb65RSaHXU9U2IIYti93kiH22hHMg0hMo/OWXssfJH5Up1aBpXYUY2J+DUprn5kAtIdYjn15KBvok7SDQ3ARJBAopS9R1/tize2rLmDgWOsmaSHkRZz0vbd1gnzWVzjVIclj2CiSBs/GWcJgtSO3spNGxpoKhBXnlnU0GSAXeemXl/pQ+9BL+6h3hl3xWJlfdLlq+y2mJgXfWDWYgZFYnQom3o5csfWKsK/5qdvFos/A8hAYKNv6jvuC+7ElxACq3OamLpDCvGChkKqP/eEO7Hfwfw1eB2hQSa8VOCb5af8/FQm+7Zb27UmZItIqnRA=


### PR DESCRIPTION
Every time a merge to `master` is done, a deploy signal will be issued to Laravel Forge by issuing a POST request to an endpoint (encrypted by Travis), which then results in the update of http://kain.jpcaparas.com.

This PR also removes Travis build on nightly PHP images, as these have been erratic as of late.